### PR TITLE
Placeholders parse on the document level

### DIFF
--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -28,6 +28,9 @@ gunicorn==19.3.0
 webassets==0.10.1
 Flask-Assets==0.10
 
+# HTML Parsing
+beautifulsoup4==4.3.2
+
 # Debug toolbar -- included because it registers as an extension
 Flask-DebugToolbar==0.9.2
 blinker==1.3

--- a/template_maker/data/placeholders.py
+++ b/template_maker/data/placeholders.py
@@ -1,9 +1,18 @@
 from template_maker.database import db
 from template_maker.builder.models import TemplatePlaceholders
+from bs4 import BeautifulSoup
 
 VARIABLE_TYPE_MAPS = {
     'text': 1, 'date': 2,'number': 3, 'float': 4
 }
+
+def get_all_placeholders(html):
+    '''
+    Uses BeautifulSoup to parse through an HTML block and
+    return all .fr-placeholder span tags
+    '''
+    soup = BeautifulSoup(html)
+    return soup.find_all('span', {'class': 'js-fr-placeholder'})
 
 def get_template_placeholders(template_id):
     '''
@@ -32,7 +41,8 @@ def parse_placeholder_text(placeholder):
     Takes a placeholder of the form [[TYPE:NAME]] and
     returns the type and the name
     '''
-    no_tags = placeholder.lstrip('[[').rstrip(']]')
+    placeholder_text = placeholder.text
+    no_tags = placeholder_text.lstrip('[[').rstrip(']]')
     var_type = no_tags.split('||')[0].lower()
     var_name = '[[' + no_tags.split('||')[1] + ']]'
     return var_type, var_name
@@ -49,7 +59,7 @@ def delete_excess_placeholders(current_placeholders, input_placeholders):
 def create_or_update_placeholder(var_idx, placeholder, input_placeholders, current_placeholders, template_id, section_id):
     _placeholder = current_placeholders[var_idx] if len(current_placeholders) > 0 and var_idx < len(current_placeholders) else TemplatePlaceholders()
     var_type, var_name = parse_placeholder_text(placeholder)
-    _placeholder.full_name = placeholder
+    _placeholder.full_name = placeholder.text
     _placeholder.display_name = var_name
     _placeholder.template_id = template_id
     _placeholder.section_id = section_id

--- a/template_maker/data/sections.py
+++ b/template_maker/data/sections.py
@@ -4,10 +4,10 @@ from sqlalchemy.dialects.postgresql import array
 from template_maker.database import db
 from template_maker.builder.models import TemplateSection, TextSection, FixedTextSection
 from template_maker.data.placeholders import (
-    delete_excess_placeholders, create_or_update_placeholder, get_section_placeholders
+    delete_excess_placeholders, create_or_update_placeholder, get_section_placeholders,
+    get_all_placeholders
 )
 
-VARIABLE_RE = re.compile('(\[\[ |\[\[).*?\|\|.*?(\]\]| \]\])')
 SECTION_TYPE_MAPS = {
     'text': TextSection, 'fixed_text': FixedTextSection,
 }
@@ -90,8 +90,8 @@ def update_section(section, template_id, form_input):
         section.text = html
         # save the text
         db.session.commit()
-        # find all placeholders, using the regex set above
-        input_placeholders = [i.group() for i in re.finditer(VARIABLE_RE, html)]
+        # find all placeholders, using beautiful soup
+        input_placeholders = get_all_placeholders(html)
         # get any existing placeholders
         current_placeholders = get_section_placeholders(section.id)
 

--- a/template_maker/static/js/froalaInit.js
+++ b/template_maker/static/js/froalaInit.js
@@ -60,8 +60,8 @@ $(function() {
 
   // get the minimum placeholder id which should one more than the total number
   // of placeholders on the page right now
-  placeholderId = Math.max(0, Math.max.apply(null, $.map(
-    $('.template-preview-content').find('.fr-placeholder'),
+  var placeholderId = Math.max(0, Math.max.apply(null, $.map(
+    $('.template-preview-content').find('.js-fr-placeholder'),
     function(d) {
       return +d.id.split('-')[2];
     }))) + 1;
@@ -86,7 +86,7 @@ $(function() {
 
   function createPlaceholderShell(modal) {
     // create a shell to insert the placeholder into
-    var shell = '<span contenteditable=false class="fr-placeholder" data-fr-verified="true" ' +
+    var shell = '<span contenteditable=false class="js-fr-placeholder" data-fr-verified="true" ' +
     'id="' + createPlaceholderId(placeholderId, false) + '"> </span>';
     return shell;
   }
@@ -135,7 +135,7 @@ $(function() {
     $('.modal-placeholder-type').val('Text');
   });
 
-  $('.froala-view').on('dblclick', '.fr-placeholder', function(e) {
+  $('.froala-view').on('dblclick', '.js-fr-placeholder', function(e) {
     editPlaceholder(e.target);
   });
 
@@ -154,7 +154,7 @@ $(function() {
   var clicking = false, _el;
 
   // if we click on a placeholder, we have an element and we are clicking
-  $('.froala-view').on('mousedown.froalaCustom.movePlaceholder', '.fr-placeholder', function(e){
+  $('.froala-view').on('mousedown.froalaCustom.movePlaceholder', '.js-fr-placeholder', function(e){
     _el = e.target;
     clicking = true;
   });

--- a/template_maker/static/less/modules/builder/_fr_placeholder.less
+++ b/template_maker/static/less/modules/builder/_fr_placeholder.less
@@ -1,6 +1,6 @@
 // Custom styles for placeholders in the text
 
-.fr-placeholder {
+.js-fr-placeholder {
   background: yellow;
   cursor: pointer;
 }

--- a/template_maker_test/unit/data/test_data.py
+++ b/template_maker_test/unit/data/test_data.py
@@ -1,3 +1,4 @@
+from bs4 import BeautifulSoup
 from template_maker_test.unit.test_base import BaseTestCase
 from template_maker.database import db
 from template_maker.builder.models import (
@@ -39,13 +40,15 @@ class BuilderUtilTest(BaseTestCase):
 
     def test_parse_placeholder_text(self):
         # simple example
-        placeholder = '[[FOO||BAR]]'
+        soup = BeautifulSoup('<span>[[FOO||BAR]]</span>')
+        placeholder = soup.find('span')
         var_type, var_name = parse_placeholder_text(placeholder)
         self.assertEquals(var_type, 'foo')
         self.assertEquals(var_name, '[[BAR]]')
 
         # complex example should still work
-        placeholder = '[[FOO||This is a LONG StrINg with Weird Characterz]]'
+        soup = BeautifulSoup('<span>[[FOO||This is a LONG StrINg with Weird Characterz]]</span>')
+        placeholder = soup.find('span')
         var_type, var_name = parse_placeholder_text(placeholder)
         self.assertEquals(var_type, 'foo')
         self.assertEquals(var_name, '[[This is a LONG StrINg with Weird Characterz]]')
@@ -72,7 +75,9 @@ class BuilderUtilTest(BaseTestCase):
         placeholder = insert_new_placeholder(section.id)
 
         new_content = {
-            'widget': 'this is a [[Text||foo]] [[Text||bar]] [[Text||baz]] update'
+            'widget': 'this is a <span class="js-fr-placeholder">[[Text||foo]]</span>' +
+            '<span class="js-fr-placeholder">[[Text||bar]]</span>' +
+            '<span class="js-fr-placeholder">[[Text||baz]]</span> update'
         }
 
         update_section(section, template.id, new_content)
@@ -80,7 +85,7 @@ class BuilderUtilTest(BaseTestCase):
         self.assertEquals(section.text, new_content.get('widget'))
 
         new_content2 = {
-            'widget': 'this is a section with fewer placeholders [[Text||foo]]'
+            'widget': 'this is a section with fewer placeholders <span class="js-fr-placeholder">[[Text||foo]]</span>'
         }
 
         update_section(section, template.id, new_content2)


### PR DESCRIPTION
### What Changed
- Added [`bs4`](http://www.crummy.com/software/BeautifulSoup/bs4/doc/) as a dependency
- Moved placeholder detection out of a regex and onto the document itself
### Issues
- Fixes #30 
### Screencap

None, no functionality change.
